### PR TITLE
Add dark mode / theme selection.

### DIFF
--- a/docs/css/calc_style.css
+++ b/docs/css/calc_style.css
@@ -1,3 +1,15 @@
+h1, h2, h3, h4, h5, h6, p, div, span, sup, sub, label {
+	color: #000;
+}
+
+a:visited {
+	color:#40a;
+}
+
+a, a.no_visited:visited {
+	color:#00a;
+}
+
 h1 { margin: 5px; }
 
 .raw_calc_io {
@@ -27,9 +39,17 @@ button.num				{ background-color:lightgrey; }
 button.num				{ background-color:#DDD; }
 button.num:hover		{ background-color:#BBB; }
 
-.btn {
+.btn, button {
 	/* the default is fine on firefox, but too dark on chrome */
 	border-color: #ababab7a;
+
+	background-color:#aaa;
+	color:#000;
+}
+
+textarea, input {
+	color:#000;
+	background-color:#fff;
 }
 
 button:disabled, button:disabled:hover {
@@ -44,7 +64,7 @@ button.btn:hover:disabled {
 	font-weight:normal;
 }
 
-button.unused { visibility:hidden; }
+.btn.unused { visibility:hidden; }
 
 div.main {
 }

--- a/docs/css/calc_style_dark.css
+++ b/docs/css/calc_style_dark.css
@@ -1,117 +1,120 @@
-button.btn_important		{ background-color:#300; }
-button.btn_important:hover	{ background-color:#622; }
-button.meta				{ background-color:#210; }
-button.meta:hover		{ background-color:#420; }
-button.func             { background-color:#181818; }
-button.var              { background-color:#182218; }
-button.func:hover, button.var:hover	{ background-color:#333; }
-button.op				{ background-color:#001; }
-button.op:hover			{ background-color:#003; }
-button.specop			{ background-color:#001; }
-button.specop:hover		{ background-color:#003; }
-button.num				{ background-color:#282828; }
-button.num:hover		{ background-color:#333; }
+body.dark button.btn_important		    { background-color:#602424; }
+body.dark button.btn_important:hover	{ background-color:#502020; }
+body.dark button.meta				    { background-color:#540; }
+body.dark button.meta:hover		        { background-color:#430; }
+body.dark button.func                   { background-color:#206065; }
+body.dark button.var                    { background-color:#255813; }
+body.dark button.func:hover, button.var:hover	{ background-color:#333; }
+body.dark button.op				        { background-color:#2A2A8A; }
+body.dark button.op:hover			    { background-color:#1A1A7A; }
+body.dark button.specop			        { background-color:#2A2A8A; }
+body.dark button.specop:hover		    { background-color:#1A1A7A; }
+body.dark button.num				    { background-color:#464646; }
+body.dark button.num:hover		        { background-color:#363636; }
 
-select {
+body.dark select {
 	background-color:#111;
-	color:#888;
+	color:#fff;
 	/* border:1px solid black; */
 }
 
-a:visited {
-	color:#636;
+body.dark .error_msg { color: red; }
+
+body.dark a:visited {
+	color:#80f;
 }
 
-a, a.no_visited:visited {
-	color:#558;
+body.dark a, body.dark a.no_visited:visited {
+	color:#00f;
 }
 
 
-button.btn {
-	color:#888;
+body.dark .btn {
+	color:#fff;
+	border:1px solid black;
+	background-color:#222;
+}
+
+body.dark .var_btn_ctrl_style {
+    color:#fff;
 	border:1px solid black;
 }
 
-.var_btn_ctrl_style {
-    color:#888;
-	border:1px solid black;
-}
-
-textarea {
+body.dark textarea, body.dark input {
 	border:1px solid darkgrey;
 	background-color:black;
-	color:grey;
+	color:#fff;
 }
 
-button.unused { visibility:hidden; }
+body.dark .btn.unused { visibility:hidden; }
 
-.output_txt_cls {
-	background-color:#000;
+body.dark .output_txt_cls {
+	background-color:#222;
 	border:1px solid grey;
 }
 
-.output_txt_cls > * > p {
+body.dark .output_txt_cls > * > p {
 	border-bottom:1px dashed #111;
 }
 
-.popup_cls {
+body.dark .popup_cls {
 	background-color: #111111dd;
 }
 
-.var_tbl_div > * > thead {
+body.dark .var_tbl_div > * > thead {
 	background-color: black;
 }
 
-.var_tbl_div > table {
+body.dark .var_tbl_div > table {
 	background-color: black;
 }
 
-tr.var_table_row:hover {
+body.dark tr.var_table_row:hover {
 	background-color:#00002288;
 	border: 1px solid darkgrey;
 	cursor: pointer;
 }
 
-tr.selected {
+body.dark tr.selected {
 	border: 1px solid darkgrey;
 }
 
-.selected {
+body.dark .selected {
 	background-color:#00004488 !important;
 }
 
-.var_btn_style {
+body.dark .var_btn_style {
     border:1px solid #222;
-	color:#666;
+	color:#fff;
 	background-color:black;
 }
 
-.var_display_btn {
-    color:#666;
+body.dark .var_display_btn {
+    color:#fff;
     background-color:black;
 }
 
-#custom_var_name_input {
+body.dark #custom_var_name_input {
     border:1px solid black;
-    color:darkgrey;
+    color:#fff;
     background-color:black;
 }
 
-.popup_btn_ctrl_style {
-	color: #666;
+body.dark .popup_btn_ctrl_style {
+	color: #fff;
 }
 
-.unit_sel_item {
+body.dark .unit_sel_item {
 	color: #555599;
 }
 
-.unit_sel_item:visited {
+body.dark .unit_sel_item:visited {
 	color: #555599;
 }
 
-.license {
+body.dark .license {
 	border: 1px solid darkgrey;
 	background-color:black;
-	color:#666;
+	color:#fff;
 	overflow:auto;
 }

--- a/docs/css/calc_style_very_dark.css
+++ b/docs/css/calc_style_very_dark.css
@@ -1,0 +1,120 @@
+body.very_dark button.btn_important		{ background-color:#300; }
+body.very_dark button.btn_important:hover	{ background-color:#622; }
+body.very_dark button.meta				{ background-color:#210; }
+body.very_dark button.meta:hover		{ background-color:#420; }
+body.very_dark button.func             { background-color:#181818; }
+body.very_dark button.var              { background-color:#182218; }
+body.very_dark button.func:hover, button.var:hover	{ background-color:#333; }
+body.very_dark button.op				{ background-color:#001; }
+body.very_dark button.op:hover			{ background-color:#003; }
+body.very_dark button.specop			{ background-color:#001; }
+body.very_dark button.specop:hover		{ background-color:#003; }
+body.very_dark button.num				{ background-color:#282828; }
+body.very_dark button.num:hover		{ background-color:#333; }
+
+body.very_dark select {
+	background-color:#111;
+	color:#888;
+	/* border:1px solid black; */
+}
+
+body.very_dark .error_msg { color: red; }
+
+body.very_dark a:visited {
+	color:#636;
+}
+
+body.very_dark a, body.very_dark a.no_visited:visited {
+	color:#558;
+}
+
+
+body.very_dark .btn {
+	color:#888;
+	border:1px solid black;
+	background-color:#222;
+}
+
+body.very_dark .var_btn_ctrl_style {
+    color:#888;
+	border:1px solid black;
+}
+
+body.very_dark textarea, body.very_dark input {
+	border:1px solid darkgrey;
+	background-color:black;
+	color:grey;
+}
+
+body.very_dark .btn.unused { visibility:hidden; }
+
+body.very_dark .output_txt_cls {
+	background-color:#000;
+	border:1px solid grey;
+}
+
+body.very_dark .output_txt_cls > * > p {
+	border-bottom:1px dashed #111;
+}
+
+body.very_dark .popup_cls {
+	background-color: #111111dd;
+}
+
+body.very_dark .var_tbl_div > * > thead {
+	background-color: black;
+}
+
+body.very_dark .var_tbl_div > table {
+	background-color: black;
+}
+
+body.very_dark tr.var_table_row:hover {
+	background-color:#00002288;
+	border: 1px solid darkgrey;
+	cursor: pointer;
+}
+
+body.very_dark tr.selected {
+	border: 1px solid darkgrey;
+}
+
+body.very_dark .selected {
+	background-color:#00004488 !important;
+}
+
+body.very_dark .var_btn_style {
+    border:1px solid #222;
+	color:#666;
+	background-color:black;
+}
+
+body.very_dark .var_display_btn {
+    color:#666;
+    background-color:black;
+}
+
+body.very_dark #custom_var_name_input {
+    border:1px solid black;
+    color:darkgrey;
+    background-color:black;
+}
+
+body.very_dark .popup_btn_ctrl_style {
+	color: #666;
+}
+
+body.very_dark .unit_sel_item {
+	color: #555599;
+}
+
+body.very_dark .unit_sel_item:visited {
+	color: #555599;
+}
+
+body.very_dark .license {
+	border: 1px solid darkgrey;
+	background-color:black;
+	color:#666;
+	overflow:auto;
+}

--- a/docs/css/style_dark.css
+++ b/docs/css/style_dark.css
@@ -1,16 +1,25 @@
-h1, h2, h3, h4, h5, h6, p, div, span, sup, sub, label {
-	color: #666;
+/* html:not(.style-scope)[dark] { */
+
+body.dark h1, body.dark h2, body.dark h3, body.dark h4, body.dark h5, body.dark h6, body.dark p, body.dark div, body.dark span, body.dark sup, body.dark sub, body.dark label {
+	/*color: #fff;*/
+	/* Chrome `#enable-force-dark` seems to invert colours brighter than this,
+	* at least for the MathJax fraction bar and line in square root symbols.
+	* Using #cdcdcd appears to prevent it from getting inverted, but
+	* Using #cecece (or #fff) will result it in being changed to something 
+	* dark.
+	*/
+	color: #cdcdcd;
 }
 
-body {
+body.dark {
 	background-color: #000;
 }
 
-div.main{
+body.dark div.main {
 	background-color:#111;
 	border: 1px solid grey;
 }
 
-.unimportant{
+body.dark .unimportant {
 	color:gray;
 }

--- a/docs/css/style_very_dark.css
+++ b/docs/css/style_very_dark.css
@@ -1,0 +1,16 @@
+body.very_dark h1, body.very_dark h2, body.very_dark h3, body.very_dark h4, body.very_dark h5, body.very_dark h6, body.very_dark p, body.very_dark div, body.very_dark span, body.very_dark sup, body.very_dark sub, body.very_dark label {
+	color: #666;
+}
+
+body.very_dark {
+	background-color: #000;
+}
+
+body.very_dark div.main {
+	background-color:#111;
+	border: 1px solid grey;
+}
+
+body.very_dark .unimportant {
+	color:gray;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,15 +8,16 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
 	<meta name="apple-mobile-web-app-capable" content="yes">
 	<meta name="mobile-web-app-capable" content="yes">
+	<meta name="color-scheme" content="light dark">
 	<link rel="icon" type="image/png" href="graphics/favicon.png">
 	<link rel="apple-touch-icon" href="graphics/favicon.png">
 
-	<link rel="stylesheet" type="text/css" href="css/style.css">
-	<link rel="stylesheet" type="text/css" href="css/calc_style.css">
-	<!--
+	<link rel="stylesheet" type="text/css" href="css/style_very_dark.css">
+	<link rel="stylesheet" type="text/css" href="css/calc_style_very_dark.css">
 	<link rel="stylesheet" type="text/css" href="css/style_dark.css">
 	<link rel="stylesheet" type="text/css" href="css/calc_style_dark.css">
-	-->
+	<link rel="stylesheet" type="text/css" href="css/style.css">
+	<link rel="stylesheet" type="text/css" href="css/calc_style.css">
 	<script type="text/javascript" src="js/dropdown_and_inc_widget.js"></script>
 	<!-- TODO figure out how to include this file from within calc_ui.js -->
 	<script type="text/javascript" src="js/calc_ui_unit_sel.js"></script>
@@ -343,7 +344,13 @@
 
 	<div class="output_text_window_container">
 		<div class="output_btn_container">
-		<div class="output_btns">
+		<div class="output_btns" style="text-align:right">
+			<select id="dark_mode_select">
+				<option value="light">Light mode</option>
+				<option value="dark">Dark mode</option>
+				<option value="very_dark">Very dark mode</option>
+			</select>
+			<br/>
 			<label for="checkbox_show_raw">Show raw</label>
 			<input type="checkbox" id="checkbox_show_raw">
 		</div>
@@ -647,6 +654,19 @@
 			<li><a class="licenses" href="licenses.html">Licenses</a></li>
 		</ul>
 	</div>
+
+	<!--
+	   Detecting whether "forced dark mode" is enabled on chrome, since for some reason it doesn't
+	   cause the {typical test for whether or not the user wants darkmode} to return true, which is:
+	  
+	       window.matchMedia("(prefers-color-scheme: dark)")
+	  
+	   So this is an unfortunate hack.
+	   The alternative would be to let chrome invert my light theme willy-nilly, but that doesn't seem to work
+	   very well with my (perhaps poor) choice of light mode colours.
+	   See https://developer.chrome.com/blog/auto-dark-theme/#detecting-auto-dark-theme
+	-->
+	<div id="auto_dark_mode_detection" style="display: none; background-color: canvas; color-scheme: light;"></div>
 
 
 	<script>
@@ -1063,6 +1083,8 @@
 			output_text_window: document.getElementById("output_text_window"),
 
 			checkbox_show_raw: document.getElementById("checkbox_show_raw"),
+			selected_theme: "light",
+			dark_mode_select: document.getElementById("dark_mode_select"),
 
 			custom_var_name_input: document.getElementById("custom_var_name_input"),
 			var_selector_display: document.getElementById("var_selector"),

--- a/docs/js/calc_ui.js
+++ b/docs/js/calc_ui.js
@@ -815,6 +815,44 @@ function handle_degree_toggle(ui) {
 	update_latex_display(ui);
 }
 
+const SUPPORTED_THEMES = [
+	"light",
+	"dark",
+	"very_dark",
+];
+
+function set_theme(ui, theme) {
+	console.debug("Setting theme to ", theme);
+	if (!SUPPORTED_THEMES.includes(theme)) {
+		console.error("unsupported theme", theme);
+		return;
+	}
+	document.body.classList.add(theme);
+	for (let old_theme of SUPPORTED_THEMES) {
+		if (old_theme != theme) {
+			document.body.classList.remove(old_theme);
+		}
+	}
+}
+
+function set_dark_mode_select(ui, theme) {
+	for (let i=0; i<ui.dark_mode_select.options.length; i++) {
+		let option = ui.dark_mode_select.options[i];
+		if (option.value == theme) {
+			ui.dark_mode_select.selectedIndex = i;
+			return;
+		}
+	}
+	console.error("theme ", theme, "not found in select");
+	
+}
+
+// See https://developer.chrome.com/blog/auto-dark-theme/#detecting-auto-dark-theme
+function check_forced_dark_mode() {
+	let elem = document.querySelector('#auto_dark_mode_detection');
+	return getComputedStyle(elem).backgroundColor != 'rgb(255, 255, 255)';
+}
+
 function init_ui_throws(ui) {
 	console.debug("Initializing Calc UI");
 	ui.state = init_ui_state();
@@ -835,6 +873,20 @@ function init_ui_throws(ui) {
 
 	ui.checkbox_show_raw.checked = ui.state.show_raw_calc_io
 	ui.checkbox_show_raw.addEventListener('click', function (e) { toggle_show_raw(ui) });
+
+	let darkMatch = window.matchMedia("(prefers-color-scheme: dark)");
+	if (darkMatch && darkMatch.matches) {
+		ui.selected_theme = "dark";
+	} else if (check_forced_dark_mode()) {
+		console.log("User has #force-dark-mode enabled, but not ('prefers-color-scheme: dark)!!!");
+		ui.selected_theme = "dark";
+	}
+
+	
+	console.debug("OS default for dark mode is: ", ui.selected_theme);
+	set_dark_mode_select(ui, ui.selected_theme);
+	set_theme(ui, ui.selected_theme);
+	ui.dark_mode_select.addEventListener('change', function (e) { set_theme(ui, e.target.value); });
 
 	for (let info of ui_btn_handlers) {
 		info.btn.addEventListener('click', info.handler);

--- a/docs/js/calc_ui.js
+++ b/docs/js/calc_ui.js
@@ -874,7 +874,11 @@ function init_ui_throws(ui) {
 	ui.checkbox_show_raw.checked = ui.state.show_raw_calc_io
 	ui.checkbox_show_raw.addEventListener('click', function (e) { toggle_show_raw(ui) });
 
-	let darkMatch = window.matchMedia("(prefers-color-scheme: dark)");
+	let darkMatch;
+	if (window.matchMedia) {
+		darkMatch = window.matchMedia("(prefers-color-scheme: dark)");
+	}
+
 	if (darkMatch && darkMatch.matches) {
 		ui.selected_theme = "dark";
 	} else if (check_forced_dark_mode()) {


### PR DESCRIPTION
* adds "dark" and "very dark" themes, in addition to the existing "light" theme
* adds the ability for the user to select the theme from a dropdown in the top right
* automatically selects the theme based on user preference, using `window.matchMedia("(prefers-color-scheme: dark)")`, and checks if the chrome flag `#enable-force-dark` is set [with this method](https://developer.chrome.com/blog/auto-dark-theme/#detecting-auto-dark-theme)
* dark theme must set MathJax foreground content, specifically the fraction bar and square root line, to no brighter than `#cdcdcd`, or the chrome `#enable-force-dark` flag seems to invert it somewhat. (Previously I was using `#fff` and that was getting inverted to black)