### PR TITLE
html: set position: relative and overflow-x: hidden on div.main

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -82,11 +82,13 @@
 
 
 	div.main {
+		position: relative;
 		height: calc(100% - 2*5px);
 		margin: 5px auto;
 		display:flex;
 		flex-direction:column;
 		padding: 5px; /* TODO  I'm not sure if this is causing the window to be slightly too big on android firefox */
+		overflow-x: hidden;
 	}
 
 	/* TODO try out aligning content to bottom of this, to be closer to the buttons?


### PR DESCRIPTION
This seems to prevent Safari (iOS, not macOS) from allowing
horizontal scrolling (for the custom colour selector), but it doesn't seem to be necessary on the other browsers.